### PR TITLE
tracef for formatted output, basic trace for trace like in ActionScript

### DIFF
--- a/framework/include/kw/utilities/internal/trace_impl.h
+++ b/framework/include/kw/utilities/internal/trace_impl.h
@@ -16,9 +16,26 @@
 #include <kw/utilities/trace.h>
 
 namespace kw {
-template <typename string, typename... Args>
-void trace(string format_str, const Args&... args) {
+namespace trace_details {
+void trace() {
+    std::cout << std::endl;
+}
+
+template <typename Arg, typename... Args>
+void trace(const Arg& argument, const Args&... args) {
+    std::cout << argument << ' ';
+    trace(args...);
+}
+} // namespace trace_details
+
+template <typename... Args>
+void tracef(const String& format_str, const Args&... args) {
     const String str = fmt::format(format_str, args...);
-    puts(str.c_str());
+    std::cout << str.c_str() << std::endl;
+}
+
+template <typename... Args>
+void trace(const Args&... args) {
+    trace_details::trace(args...);
 }
 } // namespace kw

--- a/framework/include/kw/utilities/trace.h
+++ b/framework/include/kw/utilities/trace.h
@@ -13,16 +13,25 @@
 
 #pragma once
 
-#include <fmt/format.h>
+#include <kw/base/string.h>
 
-#include <cstdio>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <iostream>
 
 namespace kw {
 /**
  * Writes the formatted string 'format_str' to the standard output (stdout).
  */
 template <typename string, typename... Args>
-void trace(string format_str, const Args&... args);
+void tracef(const String& format_str, const Args&... args);
+
+/**
+ * Writes the given 'args' to the standard output (stdout) separated by a single space.
+ */
+template <typename... Args>
+void trace(const Args&... args);
 } // namespace kw
 
 #include <kw/utilities/internal/trace_impl.h>

--- a/program/testbed/source/main.cpp
+++ b/program/testbed/source/main.cpp
@@ -60,7 +60,7 @@ void Game::test_input() {
         const bool is_released = keyboard.is_released(i);
         const kw::String& text = keyboard.get_text();
         if (is_pressed || is_down || is_repeat || is_released) {
-            kw::trace("Keyboard Button #{} ('{}')     P: {}, D: {}, Rep: {}, Rel: {}, Txt: {}", static_cast<kw::int32>(i), kw::ControlUtils::get_control_name(i), is_pressed, is_down, is_repeat, is_released, text);
+            kw::tracef("Keyboard Button #{} ('{}')     P: {}, D: {}, Rep: {}, Rel: {}, Txt: {}", static_cast<kw::int32>(i), kw::ControlUtils::get_control_name(i), is_pressed, is_down, is_repeat, is_released, text);
         }
     }
 
@@ -68,7 +68,7 @@ void Game::test_input() {
     const auto [mx, my] = mouse.get_position();
     const kw::int32 wheel = mouse.get_wheel();
     if (wheel != 0) {
-        kw::trace("Mouse Wheel {}", wheel);
+        kw::trace("Mouse Wheel", wheel);
     }
     for (kw::Control i = kw::ControlUtils::MOUSE_BEGIN; i <= kw::ControlUtils::MOUSE_END; i = static_cast<kw::Control>(static_cast<kw::int32>(i) + 1)) {
         // This assert is excess, just for testing
@@ -78,7 +78,7 @@ void Game::test_input() {
         const bool is_down = mouse.is_down(i);
         const bool is_released = mouse.is_released(i);
         if (is_pressed || is_down || is_released) {
-            kw::trace("Mouse Button #{} ('{}')     P: {}, D: {}, R: {}, X: {}, Y: {}", static_cast<kw::int32>(i), kw::ControlUtils::get_control_name(i), is_pressed, is_down, is_released, mx, my);
+            kw::tracef("Mouse Button #{} ('{}')     P: {}, D: {}, R: {}, X: {}, Y: {}", static_cast<kw::int32>(i), kw::ControlUtils::get_control_name(i), is_pressed, is_down, is_released, mx, my);
         }
     }
 
@@ -93,7 +93,7 @@ void Game::test_input() {
             const bool is_down = gamepad.is_down(j);
             const bool is_released = gamepad.is_released(j);
             if (is_pressed || is_down || is_released) {
-                kw::trace("Gamepad #{} Button #{} ('{}')     P: {}, D: {}, R: {}", i, static_cast<kw::int32>(j), kw::ControlUtils::get_control_name(j), is_pressed, is_down, is_released);
+                kw::tracef("Gamepad #{} Button #{} ('{}')     P: {}, D: {}, R: {}", i, static_cast<kw::int32>(j), kw::ControlUtils::get_control_name(j), is_pressed, is_down, is_released);
             }
         }
         for (kw::Control j = kw::ControlUtils::GAMEPAD_AXES_BEGIN; j <= kw::ControlUtils::GAMEPAD_AXES_END; j = static_cast<kw::Control>(static_cast<kw::int32>(j) + 1)) {
@@ -102,7 +102,7 @@ void Game::test_input() {
 
             const auto [x, y] = gamepad.get_axis(j);
             if (kw::Math::abs(x) > 0.1f || kw::Math::abs(y) > 0.1f) {
-                kw::trace("Gamepad #{} Axis #{} ('{}')     X: {}, Y: {}", i, static_cast<kw::int32>(j), kw::ControlUtils::get_control_name(j), x, y);
+                kw::tracef("Gamepad #{} Axis #{} ('{}')     X: {}, Y: {}", i, static_cast<kw::int32>(j), kw::ControlUtils::get_control_name(j), x, y);
             }
         }
     }


### PR DESCRIPTION
The `kw::trace("format", ...)` was not that convenient.